### PR TITLE
fix: use sparkplug-client 3.2.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -428,74 +428,73 @@
       "integrity": "sha1-p3c2C1s5oaLlEG+OhY8v0tBgxXA="
     },
     "@serialport/binding-abstract": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/@serialport/binding-abstract/-/binding-abstract-2.0.5.tgz",
-      "integrity": "sha512-oRg0QRsXJFKHQbQjmo0regKLZ9JhjLmTqc47ocJgYM5UtU9Q1VFrVPh0B2lr2pfm/tr3aNvTLX1eiVAvXyZ/bg==",
+      "version": "8.0.6",
+      "resolved": "https://registry.npmjs.org/@serialport/binding-abstract/-/binding-abstract-8.0.6.tgz",
+      "integrity": "sha512-1swwUVoRyQ9ubxrkJ8JPppykohUpTAP4jkGr36e9NjbVocSPfqeX6tFZFwl/IdUlwJwxGdbKDqq7FvXniCQUMw==",
       "requires": {
         "debug": "^4.1.1"
       }
     },
     "@serialport/binding-mock": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/@serialport/binding-mock/-/binding-mock-2.0.5.tgz",
-      "integrity": "sha512-1kD1qI686pIIolGZ6TPjAtvy8c3XIUlE4OXRZf7ZHaZgGaOUHAUMLKZt4tNTxsfedRTFyiYyHoe5QAbx82R9pQ==",
+      "version": "8.0.6",
+      "resolved": "https://registry.npmjs.org/@serialport/binding-mock/-/binding-mock-8.0.6.tgz",
+      "integrity": "sha512-BIbY5/PsDDo0QWDNCCxDgpowAdks+aZR8BOsEtK2GoASTTcJCy1fBwPIfH870o7rnbH901wY3C+yuTfdOvSO9A==",
       "requires": {
-        "@serialport/binding-abstract": "^2.0.5",
+        "@serialport/binding-abstract": "^8.0.6",
         "debug": "^4.1.1"
       }
     },
     "@serialport/bindings": {
-      "version": "2.0.8",
-      "resolved": "https://registry.npmjs.org/@serialport/bindings/-/bindings-2.0.8.tgz",
-      "integrity": "sha512-paKLa9JkoH5FAy2sATTdXLCiKpuKn0pN15/etcCqzX8vi25fnQgJ8Yx9Z6zdbcKe1No7s/9PuH9yfjDR61fbOQ==",
+      "version": "8.0.7",
+      "resolved": "https://registry.npmjs.org/@serialport/bindings/-/bindings-8.0.7.tgz",
+      "integrity": "sha512-IqudDL8ne2Y2S0W5fKA6wdgHCIA2e2OIaPVYhGy6duE6legNHFY+05CLicHAyAeTocXmHU7rVNxzVQrOG5tM4g==",
       "requires": {
-        "@serialport/binding-abstract": "^2.0.5",
-        "@serialport/parser-readline": "^2.0.2",
-        "bindings": "^1.3.0",
+        "@serialport/binding-abstract": "^8.0.6",
+        "@serialport/parser-readline": "^8.0.6",
+        "bindings": "^1.5.0",
         "debug": "^4.1.1",
-        "nan": "^2.13.2",
-        "prebuild-install": "^5.2.1"
+        "nan": "^2.14.0",
+        "prebuild-install": "^5.3.0"
       }
     },
     "@serialport/parser-byte-length": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/@serialport/parser-byte-length/-/parser-byte-length-2.0.2.tgz",
-      "integrity": "sha512-cUOprk1uRLucCJy6m+wAM4pwdBaB5D4ySi6juwRScP9DTjKUvGWYj5jzuqvftFBvYFmFza89aLj5K23xiiqj7Q=="
+      "version": "8.0.6",
+      "resolved": "https://registry.npmjs.org/@serialport/parser-byte-length/-/parser-byte-length-8.0.6.tgz",
+      "integrity": "sha512-92mrFxFEvq3gRvSM7ANK/jfbmHslz91a5oYJy/nbSn4H/MCRXjxR2YOkQgVXuN+zLt+iyDoW3pcOP4Sc1nWdqQ=="
     },
     "@serialport/parser-cctalk": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/@serialport/parser-cctalk/-/parser-cctalk-2.0.2.tgz",
-      "integrity": "sha512-5LMysRv7De+TeeoKzi4+sgouD4tqZEAn1agAVevw+7ILM0m30i1zgZLtchgxtCH7OoQRAkENEVEPc0OwhghKgw=="
+      "version": "8.0.6",
+      "resolved": "https://registry.npmjs.org/@serialport/parser-cctalk/-/parser-cctalk-8.0.6.tgz",
+      "integrity": "sha512-pqtCYQPgxnxHygiXUPCfgX7sEx+fdR/ObjpscidynEULUq2fFrC5kBkrxRbTfHRtTaU2ii9DyjFq0JVRCbhI0Q=="
     },
     "@serialport/parser-delimiter": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/@serialport/parser-delimiter/-/parser-delimiter-2.0.2.tgz",
-      "integrity": "sha512-zB02LahFfyZmJqak9l37vP/F1K+KCUxd1KQj35OhD1+0q/unMjVTZmsfkxFSM4gkaxP9j7+8USk+LQJ3V8U26Q=="
+      "version": "8.0.6",
+      "resolved": "https://registry.npmjs.org/@serialport/parser-delimiter/-/parser-delimiter-8.0.6.tgz",
+      "integrity": "sha512-ogKOcPisPMlVtirkuDu3SFTF0+xT0ijxoH7XjpZiYL41EVi367MwuCnEmXG+dEKKnF0j9EPqOyD2LGSJxaFmhQ=="
     },
     "@serialport/parser-readline": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/@serialport/parser-readline/-/parser-readline-2.0.2.tgz",
-      "integrity": "sha512-thL26dGEHB+eINNydJmzcLLhiqcBQkF+wNTbRaYblTP/6dm7JsfjYSud7bTkN63AgE0xpe9tKXBFqc8zgJ1VKg==",
+      "version": "8.0.6",
+      "resolved": "https://registry.npmjs.org/@serialport/parser-readline/-/parser-readline-8.0.6.tgz",
+      "integrity": "sha512-OYBT2mpczh9QUI3MTw8j0A0tIlPVjpVipvuVnjRkYwxrxPeq04RaLFhaDpuRzua5rTKMt89c1y3btYeoDXMjAA==",
       "requires": {
-        "@serialport/parser-delimiter": "^2.0.2"
+        "@serialport/parser-delimiter": "^8.0.6"
       }
     },
     "@serialport/parser-ready": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/@serialport/parser-ready/-/parser-ready-2.0.2.tgz",
-      "integrity": "sha512-6ynQ+HIIkFQcEO2Hrq4Qmdz+hlJ7kjTHGQ1E7SRN7f70nnys1v3HSke8mjK3RzVw+SwL0rBYjftUdCTrU+7c+Q=="
+      "version": "8.0.6",
+      "resolved": "https://registry.npmjs.org/@serialport/parser-ready/-/parser-ready-8.0.6.tgz",
+      "integrity": "sha512-xcEqv4rc119WR5JzAuu8UeJOlAwET2PTdNb6aIrrLlmTxhvuBbuRFcsnF3BpH9jUL30Kh7a6QiNXIwVG+WR/1Q=="
     },
     "@serialport/parser-regex": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/@serialport/parser-regex/-/parser-regex-2.0.2.tgz",
-      "integrity": "sha512-7qjYd7AdHUK8fJOmHpXlMRipqRCVMMyDFyf/5TQQiOt6q+BiFjLOtSpVXhakHwgnXanzDYKeRSB8zM0pZZg+LA=="
+      "version": "8.0.6",
+      "resolved": "https://registry.npmjs.org/@serialport/parser-regex/-/parser-regex-8.0.6.tgz",
+      "integrity": "sha512-J8KY75Azz5ZyExmyM5YfUxbXOWBkZCytKgCCmZ966ttwZS0bUZOuoCaZj2Zp4VILJAiLuxHoqc0foi67Fri5+g=="
     },
     "@serialport/stream": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/@serialport/stream/-/stream-2.0.5.tgz",
-      "integrity": "sha512-9gc3zPoAqs/04mvq8TdZ7GxtnacCDuw3/u0u18UXXHgC/5tNDYkY+hXFIJB1fQFnP5yyNB1L2XLfX974ySJg9Q==",
+      "version": "8.0.6",
+      "resolved": "https://registry.npmjs.org/@serialport/stream/-/stream-8.0.6.tgz",
+      "integrity": "sha512-ym1PwM0rwLrj90vRBB66I1hwMXbuMw9wGTxqns75U3N/tuNFOH85mxXaYVF2TpI66aM849NoI1jMm50fl9equg==",
       "requires": {
-        "@serialport/binding-mock": "^2.0.5",
         "debug": "^4.1.1"
       }
     },
@@ -5641,12 +5640,12 @@
       }
     },
     "modbus-serial": {
-      "version": "7.7.3",
-      "resolved": "https://registry.npmjs.org/modbus-serial/-/modbus-serial-7.7.3.tgz",
-      "integrity": "sha512-GVK6zHESIGDfOorekkQJPIvjoqdOwsEVbkRxCVOyWshNH9VZuY+MpT1CDXq4nvASSrQBer8QfYUkwoqZazdhIg==",
+      "version": "7.7.4",
+      "resolved": "https://registry.npmjs.org/modbus-serial/-/modbus-serial-7.7.4.tgz",
+      "integrity": "sha512-BJ8nPwrIQzilPPd9TR613PZlkI/AydUog6VpnoMxiAh2RIMCfhBXX//0US9sSWv/WtD/o7DouxOCbzr/MQjvtA==",
       "requires": {
         "debug": "^4.1.1",
-        "serialport": "^7.1.5"
+        "serialport": "^8.0.6"
       }
     },
     "mqtt": {
@@ -5778,9 +5777,9 @@
       "dev": true
     },
     "node-abi": {
-      "version": "2.13.0",
-      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-2.13.0.tgz",
-      "integrity": "sha512-9HrZGFVTR5SOu3PZAnAY2hLO36aW1wmA+FDsVkr85BTST32TLCA1H/AEcatVRAsWLyXS3bqUDYCAjq5/QGuSTA==",
+      "version": "2.14.0",
+      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-2.14.0.tgz",
+      "integrity": "sha512-y54KGgEOHnRHlGQi7E5UiryRkH8bmksmQLj/9iLAjoje743YS+KaKB/sDYXgqtT0J16JT3c3AYJZNI98aU/kYg==",
       "requires": {
         "semver": "^5.4.1"
       },
@@ -7002,19 +7001,19 @@
       }
     },
     "serialport": {
-      "version": "7.1.5",
-      "resolved": "https://registry.npmjs.org/serialport/-/serialport-7.1.5.tgz",
-      "integrity": "sha512-NplGdqaY+ZL8t3t5egbT+3oqLW4d7WvDT/x1ACxAyWa1fSnx+KTAmlDHeCls39lXwu8voaOr3bPOW4bwM7PdAA==",
+      "version": "8.0.7",
+      "resolved": "https://registry.npmjs.org/serialport/-/serialport-8.0.7.tgz",
+      "integrity": "sha512-R9bfNebs2dblYf5sD/Aaa7j8+siP4X7TGT02lqHM9DF5fyjlrPGXmsLw9+LKOz1AvjGjkxf2NzBVnDpqRX7clQ==",
       "requires": {
-        "@serialport/binding-mock": "^2.0.5",
-        "@serialport/bindings": "^2.0.8",
-        "@serialport/parser-byte-length": "^2.0.2",
-        "@serialport/parser-cctalk": "^2.0.2",
-        "@serialport/parser-delimiter": "^2.0.2",
-        "@serialport/parser-readline": "^2.0.2",
-        "@serialport/parser-ready": "^2.0.2",
-        "@serialport/parser-regex": "^2.0.2",
-        "@serialport/stream": "^2.0.5",
+        "@serialport/binding-mock": "^8.0.6",
+        "@serialport/bindings": "^8.0.7",
+        "@serialport/parser-byte-length": "^8.0.6",
+        "@serialport/parser-cctalk": "^8.0.6",
+        "@serialport/parser-delimiter": "^8.0.6",
+        "@serialport/parser-readline": "^8.0.6",
+        "@serialport/parser-ready": "^8.0.6",
+        "@serialport/parser-regex": "^8.0.6",
+        "@serialport/stream": "^8.0.6",
         "debug": "^4.1.1"
       }
     },
@@ -7299,64 +7298,6 @@
       "version": "3.2.2",
       "resolved": "https://registry.npmjs.org/sparkplug-client/-/sparkplug-client-3.2.2.tgz",
       "integrity": "sha512-8Kthor9gVf2ZqZas1VQmDMlECxSH8fkJY7S3lJceij3HzzkO4HUqpjNvfmRPkKp9Q5ixzzHVJmJU+tB/KPkYfw==",
-      "requires": {
-        "mqtt": "^2.16.0",
-        "pako": "^1.0.6",
-        "sparkplug-payload": "^1.0.1",
-        "winston": "^2.4.0"
-      },
-      "dependencies": {
-        "minimist": {
-          "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
-        },
-        "mqtt": {
-          "version": "2.18.8",
-          "resolved": "https://registry.npmjs.org/mqtt/-/mqtt-2.18.8.tgz",
-          "integrity": "sha512-3h6oHlPY/yWwtC2J3geraYRtVVoRM6wdI+uchF4nvSSafXPZnaKqF8xnX+S22SU/FcgEAgockVIlOaAX3fkMpA==",
-          "requires": {
-            "commist": "^1.0.0",
-            "concat-stream": "^1.6.2",
-            "end-of-stream": "^1.4.1",
-            "es6-map": "^0.1.5",
-            "help-me": "^1.0.1",
-            "inherits": "^2.0.3",
-            "minimist": "^1.2.0",
-            "mqtt-packet": "^5.6.0",
-            "pump": "^3.0.0",
-            "readable-stream": "^2.3.6",
-            "reinterval": "^1.1.0",
-            "split2": "^2.1.1",
-            "websocket-stream": "^5.1.2",
-            "xtend": "^4.0.1"
-          }
-        },
-        "mqtt-packet": {
-          "version": "5.6.1",
-          "resolved": "https://registry.npmjs.org/mqtt-packet/-/mqtt-packet-5.6.1.tgz",
-          "integrity": "sha512-eaF9rO2uFrIYEHomJxziuKTDkbWW5psLBaIGCazQSKqYsTaB3n4SpvJ1PexKaDBiPnMLPIFWBIiTYT3IfEJfww==",
-          "requires": {
-            "bl": "^1.2.1",
-            "inherits": "^2.0.3",
-            "process-nextick-args": "^2.0.0",
-            "safe-buffer": "^5.1.0"
-          }
-        },
-        "split2": {
-          "version": "2.2.0",
-          "resolved": "https://registry.npmjs.org/split2/-/split2-2.2.0.tgz",
-          "integrity": "sha512-RAb22TG39LhI31MbreBgIuKiIKhVsawfTgEGqKHTK87aG+ul/PB8Sqoi3I7kVdRWiCfrKxK3uo4/YUkpNvhPbw==",
-          "requires": {
-            "through2": "^2.0.2"
-          }
-        }
-      }
-    },
-    "sparkplug-client-jar": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/sparkplug-client-jar/-/sparkplug-client-jar-3.2.1.tgz",
-      "integrity": "sha512-MwbvsCk+y1VSfeiijd1YFV9XKgS3Nq4XoPJncTWm4pDNOxUGCl2LHf2kYOqsoskKrWTN04bimmHIEppGr2Rb8g==",
       "requires": {
         "mqtt": "^2.16.0",
         "pako": "^1.0.6",
@@ -7798,9 +7739,9 @@
           }
         },
         "readable-stream": {
-          "version": "3.4.0",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.4.0.tgz",
-          "integrity": "sha512-jItXPLmrSR8jmTRmRWJXCnGJsfy85mB3Wd/uINMXA65yrnFo0cPClFIUWzo2najVNSl+mx7/4W8ttlLWJe99pQ==",
+          "version": "3.5.0",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.5.0.tgz",
+          "integrity": "sha512-gSz026xs2LfxBPudDuI41V1lka8cxg64E66SGe78zJlsUofOg/yqwezdIcdfwik6B4h8LFmWPA9ef9X3FiNFLA==",
           "requires": {
             "inherits": "^2.0.3",
             "string_decoder": "^1.1.1",

--- a/package.json
+++ b/package.json
@@ -47,7 +47,6 @@
     "modbus-serial": "^7.7.4",
     "mqtt": "^3.0.0",
     "sparkplug-client": "^3.2.2",
-    "sparkplug-client-jar": "^3.2.1",
     "sqlite3": "^4.1.1"
   }
 }

--- a/src/service/mqtt.js
+++ b/src/service/mqtt.js
@@ -1,5 +1,5 @@
 const { Model } = require(`../database`)
-const sparkplug = require(`sparkplug-client-jar`)
+const sparkplug = require(`sparkplug-client`)
 const getUnixTime = require('date-fns/getUnixTime')
 
 class Mqtt extends Model {


### PR DESCRIPTION
Deleted custom sparkplug-client-jar that was used to workround NDEATH bug in 3.2.1, and implemented 3.2.2.