### PR TITLE
Fix: uuid in production

### DIFF
--- a/src/auth.js
+++ b/src/auth.js
@@ -3,7 +3,8 @@ const jwt = require('jsonwebtoken')
 const { executeUpdate, Model } = require('./database')
 const uuidv1 = require('uuid/v1')
 
-const APP_SECRET = 'temporary' //uuidv1()
+const APP_SECRET =
+  process.env.NODE_ENV === 'development' ? 'development_secret' : uuidv1()
 
 class User extends Model {
   static async initialize(db, pubsub) {


### PR DESCRIPTION
and temporary key in development so we don't have to login every time the server reboots, but use random uuid in production (and every other environment).